### PR TITLE
Add apt-get update to vagrant file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "private_network", ip: "192.168.50.100"
   config.vm.hostname = "vagrant-docker-example"
-
+  config.vm.provision :shell, inline: "sudo apt-get update"
   config.vm.provision :docker
   config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yml", rebuild: true, run: "always"
 


### PR DESCRIPTION
This fixes an issue with not being able to install docker provisioner. Solution is from https://github.com/mitchellh/vagrant/issues/5697